### PR TITLE
Implement Dockerized markdown to PDF API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:20
 WORKDIR /app
-COPY package.json ./
+COPY package.json tsconfig.json ./
 RUN npm install && npx @puppeteer/browsers install chromium
 COPY . .
+RUN npm run build
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20
+WORKDIR /app
+COPY package.json ./
+RUN npm install && npx @puppeteer/browsers install chromium
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project exposes a small API that converts Markdown to PDF.
    ```bash
    docker compose up
    ```
-2. Send a POST request with JSON body `{ "markdown": "# Hello" }` to `http://localhost:3000/convert`.
+2. You can open `http://localhost:3000/` in your browser and test the API using the provided HTML page.
+3. Send a POST request with JSON body `{ "markdown": "# Hello" }` to `http://localhost:3000/convert` to programmatically convert text.
    The response will be a PDF document.
 
 You can customize print styles by editing `styles/print.css`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # md-to-pdf
+
+This project exposes a small API that converts Markdown to PDF.
+
+## Usage
+
+1. Build and start the container:
+   ```bash
+   docker compose up
+   ```
+2. Send a POST request with JSON body `{ "markdown": "# Hello" }` to `http://localhost:3000/convert`.
+   The response will be a PDF document.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ This project exposes a small API that converts Markdown to PDF.
    ```
 2. Send a POST request with JSON body `{ "markdown": "# Hello" }` to `http://localhost:3000/convert`.
    The response will be a PDF document.
+
+You can customize print styles by editing `styles/print.css`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,41 @@
+import { Hono } from 'hono'
+import { serve } from '@hono/node-server'
+import { marked } from 'marked'
+import puppeteer from 'puppeteer'
+import { computeSystemExecutablePath } from '@puppeteer/browsers'
+import fs from 'fs/promises'
+import path from 'path'
+
+const app = new Hono()
+const port = 3000
+
+async function getStyles() {
+  try {
+    const cssPath = path.join(process.cwd(), 'styles', 'print.css')
+    return await fs.readFile(cssPath, 'utf8')
+  } catch (err) {
+    console.warn('CSS file not found:', err)
+    return ''
+  }
+}
+
+app.post('/convert', async c => {
+  const body = await c.req.json()
+  const markdown = body.markdown || ''
+  const styles = await getStyles()
+  const html = `<!doctype html><html><head><meta charset="utf-8"><style>${styles}</style></head><body>${marked(markdown)}</body></html>`
+
+  const browser = await puppeteer.launch({
+    executablePath: computeSystemExecutablePath('chromium'),
+    headless: 'new'
+  })
+  const page = await browser.newPage()
+  await page.setContent(html, { waitUntil: 'networkidle0' })
+  const pdfBuffer = await page.pdf({ format: 'A4', printBackground: true })
+  await browser.close()
+
+  c.header('Content-Type', 'application/pdf')
+  return c.body(pdfBuffer)
+})
+
+serve({ fetch: app.fetch, port })

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "md-to-pdf",
   "type": "module",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "start": "node index.js"
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "dependencies": {
     "hono": "^3.7.1",
@@ -11,5 +12,8 @@
     "marked": "^5.0.2",
     "puppeteer": "^21.3.1",
     "@puppeteer/browsers": "^1.6.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "md-to-pdf",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "hono": "^3.7.1",
+    "@hono/node-server": "^3.7.1",
+    "marked": "^5.0.2",
+    "puppeteer": "^21.3.1",
+    "@puppeteer/browsers": "^1.6.1"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Markdown to PDF Test</title>
+</head>
+<body>
+  <h1>Markdown to PDF Test</h1>
+  <textarea id="md" rows="10" cols="80"># Hello, world!</textarea>
+  <br/>
+  <button id="convert">変換&ダウンロード</button>
+  <script>
+    document.getElementById('convert').addEventListener('click', async () => {
+      const markdown = document.getElementById('md').value;
+      const res = await fetch('/convert', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ markdown })
+      });
+      if (!res.ok) {
+        alert('Error converting markdown');
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'document.pdf';
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  </script>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import path from 'path'
 const app = new Hono()
 const port = 3000
 
-async function getStyles() {
+async function getStyles(): Promise<string> {
   try {
     const cssPath = path.join(process.cwd(), 'styles', 'print.css')
     return await fs.readFile(cssPath, 'utf8')
@@ -20,7 +20,7 @@ async function getStyles() {
 }
 
 app.post('/convert', async c => {
-  const body = await c.req.json()
+  const body = (await c.req.json()) as { markdown?: string }
   const markdown = body.markdown || ''
   const styles = await getStyles()
   const html = `<!doctype html><html><head><meta charset="utf-8"><style>${styles}</style></head><body>${marked(markdown)}</body></html>`

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,13 @@ import path from 'path'
 const app = new Hono()
 const port = 3000
 
+app.get('/', async c => {
+  const htmlPath = path.join(process.cwd(), 'public', 'index.html')
+  const html = await fs.readFile(htmlPath, 'utf8')
+  c.header('Content-Type', 'text/html; charset=utf-8')
+  return c.body(html)
+})
+
 async function getStyles(): Promise<string> {
   try {
     const cssPath = path.join(process.cwd(), 'styles', 'print.css')

--- a/styles/print.css
+++ b/styles/print.css
@@ -1,0 +1,2 @@
+@media print {
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create Hono server that converts markdown to PDF using Puppeteer
- add Dockerfile and docker-compose for one command startup
- add package.json with Hono, Puppeteer and @puppeteer/browsers
- include customizable print CSS and instructions in README

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686db7ee85d48332965b8d35a7c611c3